### PR TITLE
fix: added alias u to getUserByCredentialsQuery

### DIFF
--- a/src/api/Authentication/__tests__/queryBuilder.test.ts
+++ b/src/api/Authentication/__tests__/queryBuilder.test.ts
@@ -77,7 +77,7 @@ describe('#queryBuilder', () => {
 		test('should search database with username if defined', async () => {
 			const values = { username: 'username', phoneNumber: '', email: '' };
 			await getUserByCredentialsQuery(entityManager, values);
-			expect(entityManager.where).toHaveBeenCalledWith('username = :username', {
+			expect(entityManager.where).toHaveBeenCalledWith('u.username = :username', {
 				username: values.username
 			});
 		});
@@ -85,7 +85,7 @@ describe('#queryBuilder', () => {
 		test('should search users with phoneNumber', async () => {
 			const values = { username: '', phoneNumber: '+1-422-847-4939', email: '' };
 			await getUserByCredentialsQuery(entityManager, values);
-			expect(entityManager.where).toHaveBeenCalledWith('phoneNumber = :phoneNumber', {
+			expect(entityManager.where).toHaveBeenCalledWith('u.phoneNumber = :phoneNumber', {
 				phoneNumber: values.phoneNumber
 			});
 		});
@@ -93,7 +93,7 @@ describe('#queryBuilder', () => {
 		test('should search users with email if defined', async () => {
 			const values = { username: '', phoneNumber: '', email: 'test@test.com' };
 			await getUserByCredentialsQuery(entityManager, values);
-			expect(entityManager.where).toHaveBeenCalledWith('email = :email', {
+			expect(entityManager.where).toHaveBeenCalledWith('u.email = :email', {
 				email: values.email
 			});
 		});

--- a/src/api/Authentication/queryBuilder.ts
+++ b/src/api/Authentication/queryBuilder.ts
@@ -24,10 +24,10 @@ export const getUserByCredentialsQuery = (
 	values: { email?: string; phoneNumber?: string; username?: string }
 ) => {
 	const { email, phoneNumber, username } = values;
-	const query = manager.getRepository(Users).createQueryBuilder();
-	if (username) query.where('username = :username', { username });
-	else if (phoneNumber) query.where('phoneNumber = :phoneNumber', { phoneNumber });
-	else query.where('email = :email', { email });
+	const query = manager.getRepository(Users).createQueryBuilder('u');
+	if (username) query.where('u.username = :username', { username });
+	else if (phoneNumber) query.where('u.phoneNumber = :phoneNumber', { phoneNumber });
+	else query.where('u.email = :email', { email });
 	return query.getOne();
 };
 


### PR DESCRIPTION
I fixed the bug from typeorm where function, which always converts the search string to lowercase. So in order to prevent it, I added the createQueryBuilder alias to it. I don't know how but it always seems to fix it. Anyways, it an immediate fix, I'll create an issue on typeorm about this problem